### PR TITLE
[Fix] splitFile.py - attrib command fails on Linux/OSX

### DIFF
--- a/tools/splitFile.py
+++ b/tools/splitFile.py
@@ -42,8 +42,9 @@ def splitQuick(filepath):
         shutil.rmtree(dir)
     os.makedirs(dir)
 
-    if os.path.exists(dir):
-        subprocess.call(['attrib', '+a', dir])
+    if (os.name != "posix"):
+        if os.path.exists(dir):
+            subprocess.call(['attrib', '+a', dir])
 
     # Move input file to directory and rename it to first part
     filename = os.path.basename(filepath)
@@ -108,8 +109,9 @@ def splitCopy(filepath):
         shutil.rmtree(dir)
     os.makedirs(dir)
 
-    if os.path.exists(dir):
-        subprocess.call(['attrib', '+a', dir])
+    if (os.name != "posix"):
+        if os.path.exists(dir):
+            subprocess.call(['attrib', '+a', dir])
 
     remainingSize = fileSize
 

--- a/tools/splitFile.py
+++ b/tools/splitFile.py
@@ -15,6 +15,10 @@ startTime = datetime.now()
 splitSize = 0xFFFF0000 # 4,294,901,760 bytes
 chunkSize = 0x8000 # 32,768 bytes
 
+def checkCommand(name):
+    from shutil import which
+    return which(name) is not None
+
 from os.path import splitext
 def splitext_(path):
     if len(path.split('.')) > 2:
@@ -45,6 +49,19 @@ def splitQuick(filepath):
     if (os.name == "nt"):
         if os.path.exists(dir):
             subprocess.call(['attrib', '+a', dir])
+    elif (os.name == "posix"):
+	if checkCommand("mattrib"):
+            if os.path.exists(dir):
+                subprocess.call(['mattrib', '+a', dir])
+	else:
+            print('Could not set archivbit!')
+	    print('mtools are not installed.')
+            print('You need to set it manually for the folder! Or install mtools and restart the job.')
+	
+    else:
+	print('Could not set archivbit! Environment unknown!')
+	print('You need to set it manually for the folder!')
+	
 
     # Move input file to directory and rename it to first part
     filename = os.path.basename(filepath)
@@ -112,6 +129,19 @@ def splitCopy(filepath):
     if (os.name == "nt"):
         if os.path.exists(dir):
             subprocess.call(['attrib', '+a', dir])
+    elif (os.name == "posix"):
+	if checkCommand("mattrib"):
+            if os.path.exists(dir):
+                subprocess.call(['mattrib', '+a', dir])
+	else:
+            print('Could not set archivbit!')
+	    print('mtools are not installed.')
+            print('You need to set it manually for the folder! Or install mtools and restart the job.')
+	
+    else:
+	print('Could not set archivbit! Environment unknown!')
+	print('You need to set it manually for the folder!')
+	
 
     remainingSize = fileSize
 

--- a/tools/splitFile.py
+++ b/tools/splitFile.py
@@ -15,6 +15,8 @@ startTime = datetime.now()
 splitSize = 0xFFFF0000 # 4,294,901,760 bytes
 chunkSize = 0x8000 # 32,768 bytes
 
+FNULL = open(os.devnull, 'w')
+
 def checkCommand(name):
     from shutil import which
     return which(name) is not None

--- a/tools/splitFile.py
+++ b/tools/splitFile.py
@@ -50,18 +50,17 @@ def splitQuick(filepath):
         if os.path.exists(dir):
             subprocess.call(['attrib', '+a', dir])
     elif (os.name == "posix"):
-	if checkCommand("mattrib"):
+        if checkCommand("mattrib"):
             if os.path.exists(dir):
                 subprocess.call(['mattrib', '+a', dir])
-	else:
+        else:
             print('Could not set archivbit!')
-	    print('mtools are not installed.')
+            print('mtools are not installed.')
             print('You need to set it manually for the folder! Or install mtools and restart the job.')
-	
     else:
-	print('Could not set archivbit! Environment unknown!')
-	print('You need to set it manually for the folder!')
-	
+        print('Could not set archivbit! Environment unknown!')
+        print('You need to set it manually for the folder!')
+
 
     # Move input file to directory and rename it to first part
     filename = os.path.basename(filepath)
@@ -130,18 +129,17 @@ def splitCopy(filepath):
         if os.path.exists(dir):
             subprocess.call(['attrib', '+a', dir])
     elif (os.name == "posix"):
-	if checkCommand("mattrib"):
+        if checkCommand("mattrib"):
             if os.path.exists(dir):
                 subprocess.call(['mattrib', '+a', dir])
-	else:
+        else:
             print('Could not set archivbit!')
-	    print('mtools are not installed.')
+            print('mtools are not installed.')
             print('You need to set it manually for the folder! Or install mtools and restart the job.')
-	
     else:
-	print('Could not set archivbit! Environment unknown!')
-	print('You need to set it manually for the folder!')
-	
+        print('Could not set archivbit! Environment unknown!')
+        print('You need to set it manually for the folder!')
+
 
     remainingSize = fileSize
 

--- a/tools/splitFile.py
+++ b/tools/splitFile.py
@@ -52,7 +52,7 @@ def splitQuick(filepath):
     elif (os.name == "posix"):
         if checkCommand("mattrib"):
             if os.path.exists(dir):
-                subprocess.call(['mattrib', '+a', dir])
+                subprocess.call(['mattrib', '+a', dir, '>/dev/null', '2>&1', '||', 'echo', '"Could not set archivbit! Probably not a Windows Filesystem!"'])
         else:
             print('Could not set archivbit!')
             print('mtools are not installed.')
@@ -131,7 +131,7 @@ def splitCopy(filepath):
     elif (os.name == "posix"):
         if checkCommand("mattrib"):
             if os.path.exists(dir):
-                subprocess.call(['mattrib', '+a', dir])
+                subprocess.call(['mattrib', '+a', dir, '>/dev/null', '2>&1', '||', 'echo', '"Could not set archivbit! Probably not a Windows Filesystem!"'])
         else:
             print('Could not set archivbit!')
             print('mtools are not installed.')

--- a/tools/splitFile.py
+++ b/tools/splitFile.py
@@ -42,7 +42,7 @@ def splitQuick(filepath):
         shutil.rmtree(dir)
     os.makedirs(dir)
 
-    if (os.name != "posix"):
+    if (os.name == "nt"):
         if os.path.exists(dir):
             subprocess.call(['attrib', '+a', dir])
 
@@ -109,7 +109,7 @@ def splitCopy(filepath):
         shutil.rmtree(dir)
     os.makedirs(dir)
 
-    if (os.name != "posix"):
+    if (os.name == "nt"):
         if os.path.exists(dir):
             subprocess.call(['attrib', '+a', dir])
 

--- a/tools/splitFile.py
+++ b/tools/splitFile.py
@@ -53,7 +53,7 @@ def splitQuick(filepath):
         if checkCommand("mattrib"):
             if os.path.exists(dir):
                 try:
-                    subprocess.check_call(['mattrib', '+a', dir], stdout=FNULL, stderr=subprocess.STDOUT)
+                    subprocess.check_call(['mattrib', '+a', dir], stdout=FNULL, stderr=FNULL)
                 except subprocess.CalledProcessError:
                     print('Could not set archivbit! Probably not a Windows Filesystem!')
                 except OSError:
@@ -132,7 +132,7 @@ def splitCopy(filepath):
 
     if (os.name == "nt"):
         if os.path.exists(dir):
-            subprocess.call(['attrib', '+a', dir], stdout=FNULL, stderr=subprocess.STDOUT)
+            subprocess.call(['attrib', '+a', dir], stdout=FNULL, stderr=FNULL)
     elif (os.name == "posix"):
         if checkCommand("mattrib"):
             if os.path.exists(dir):

--- a/tools/splitFile.py
+++ b/tools/splitFile.py
@@ -52,7 +52,12 @@ def splitQuick(filepath):
     elif (os.name == "posix"):
         if checkCommand("mattrib"):
             if os.path.exists(dir):
-                subprocess.call(['mattrib', '+a', dir, '>/dev/null', '2>&1', '||', 'echo', '"Could not set archivbit! Probably not a Windows Filesystem!"'])
+                try:
+                    subprocess.check_call(['mattrib', '+a', dir])
+                except subprocess.CalledProcessError:
+                    print('Could not set archivbit! Probably not a Windows Filesystem!')
+                except OSError:
+                    pass # executable not found
         else:
             print('Could not set archivbit!')
             print('mtools are not installed.')
@@ -131,7 +136,12 @@ def splitCopy(filepath):
     elif (os.name == "posix"):
         if checkCommand("mattrib"):
             if os.path.exists(dir):
-                subprocess.call(['mattrib', '+a', dir, '>/dev/null', '2>&1', '||', 'echo', '"Could not set archivbit! Probably not a Windows Filesystem!"'])
+                try:
+                    subprocess.check_call(['mattrib', '+a', dir])
+                except subprocess.CalledProcessError:
+                    print('Could not set archivbit! Probably not a Windows Filesystem!')
+                except OSError:
+                    pass # executable not found
         else:
             print('Could not set archivbit!')
             print('mtools are not installed.')

--- a/tools/splitFile.py
+++ b/tools/splitFile.py
@@ -26,7 +26,7 @@ def splitext_(path):
     if len(path.split('.')) > 2:
         return path.split('.')[0],'.'.join(path.split('.')[-2:])
     return splitext(path)
-	
+    
 def splitQuick(filepath):
     fileSize = os.path.getsize(filepath)
     info = shutil.disk_usage(os.path.dirname(os.path.abspath(filepath)))
@@ -55,7 +55,7 @@ def splitQuick(filepath):
         if checkCommand("mattrib"):
             if os.path.exists(dir):
                 try:
-                    subprocess.check_call(['attrib', '+a', dir], stdin=FNULL, stdout=FNULL, stderr=FNULL)
+                    subprocess.check_call(['mattrib', '+a', dir], stdin=FNULL, stdout=FNULL, stderr=FNULL)
                 except subprocess.CalledProcessError:
                     print('Could not set archivbit! Probably not a Windows Filesystem!')
                 except OSError:
@@ -134,12 +134,12 @@ def splitCopy(filepath):
 
     if (os.name == "nt"):
         if os.path.exists(dir):
-            subprocess.check_call(['attrib', '+a', dir], stdin=FNULL, stdout=FNULL, stderr=FNULL)
+            subprocess.check_call(['attrib', '+a', dir])
     elif (os.name == "posix"):
         if checkCommand("mattrib"):
             if os.path.exists(dir):
                 try:
-                    subprocess.check_call(['mattrib', '+a', dir])
+                    subprocess.check_call(['mattrib', '+a', dir], stdin=FNULL, stdout=FNULL, stderr=FNULL)
                 except subprocess.CalledProcessError:
                     print('Could not set archivbit! Probably not a Windows Filesystem!')
                 except OSError:

--- a/tools/splitFile.py
+++ b/tools/splitFile.py
@@ -53,7 +53,7 @@ def splitQuick(filepath):
         if checkCommand("mattrib"):
             if os.path.exists(dir):
                 try:
-                    subprocess.check_call(['mattrib', '+a', dir])
+                    subprocess.check_call(['mattrib', '+a', dir], stdout=FNULL, stderr=subprocess.STDOUT)
                 except subprocess.CalledProcessError:
                     print('Could not set archivbit! Probably not a Windows Filesystem!')
                 except OSError:
@@ -132,7 +132,7 @@ def splitCopy(filepath):
 
     if (os.name == "nt"):
         if os.path.exists(dir):
-            subprocess.call(['attrib', '+a', dir])
+            subprocess.call(['attrib', '+a', dir], stdout=FNULL, stderr=subprocess.STDOUT)
     elif (os.name == "posix"):
         if checkCommand("mattrib"):
             if os.path.exists(dir):

--- a/tools/splitFile.py
+++ b/tools/splitFile.py
@@ -55,7 +55,7 @@ def splitQuick(filepath):
         if checkCommand("mattrib"):
             if os.path.exists(dir):
                 try:
-                    subprocess.check_call(['mattrib', '+a', dir], stdout=FNULL, stderr=FNULL)
+                    subprocess.check_call(['attrib', '+a', dir], stdin=FNULL, stdout=FNULL, stderr=FNULL)
                 except subprocess.CalledProcessError:
                     print('Could not set archivbit! Probably not a Windows Filesystem!')
                 except OSError:
@@ -134,7 +134,7 @@ def splitCopy(filepath):
 
     if (os.name == "nt"):
         if os.path.exists(dir):
-            subprocess.call(['attrib', '+a', dir], stdout=FNULL, stderr=FNULL)
+            subprocess.check_call(['attrib', '+a', dir], stdin=FNULL, stdout=FNULL, stderr=FNULL)
     elif (os.name == "posix"):
         if checkCommand("mattrib"):
             if os.path.exists(dir):


### PR DESCRIPTION
The splitFile.py script fails on Linux and OSX without this modification as the 'attrib' command is not available on those systems ( probably includes java environments, but I only checked ubuntu and osx)

This fix prevents this function to be executed if the environment is a non-windows one